### PR TITLE
feat: replace community.kubernetes with kubernetes.core and add missing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ All-in-one container image for OpenShift CI/CD pipelines. Based on Red Hat UBI 9
 |------|-------------|
 | `openshift-install` | OpenShift cluster installer |
 | `oc` / `kubectl` | OpenShift and Kubernetes CLI |
-| `ansible` | Automation engine with `community.kubernetes` and `community.vmware` collections |
+| `ansible` | Automation engine with `kubernetes.core`, `ansible.netcommon` and `community.vmware` collections |
 | `helm` | Kubernetes package manager |
 | `helmfile` | Declarative Helm chart management |
 | `vault` | HashiCorp Vault CLI |

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,9 +1,9 @@
 collections:
   - name: ansible.netcommon
     version: 8.4.0
-  - name: community.kubernetes
-    version: 2.0.1
   - name: community.hashi_vault
     version: 7.1.0
+  - name: kubernetes.core
+    version: 6.3.0
   - name: community.vmware
     version: 6.2.0

--- a/tests/image.tests.yaml
+++ b/tests/image.tests.yaml
@@ -20,3 +20,15 @@ commandTests:
   - name: "ansible exists"
     command: "ansible"
     args: ["--version"]
+  - name: "helmfile exists"
+    command: "helmfile"
+    args: ["version"]
+  - name: "vault exists"
+    command: "vault"
+    args: ["version"]
+  - name: "govc exists"
+    command: "govc"
+    args: ["version"]
+  - name: "yq exists"
+    command: "yq"
+    args: ["--version"]


### PR DESCRIPTION
## Summary

- Migrate from deprecated `community.kubernetes` (2.0.1) to `kubernetes.core` (6.3.0)
- Add container structure tests for helmfile, vault, govc and yq
- Update README to reflect current ansible collections

## Test plan

- [ ] CI pipeline builds image successfully
- [ ] All container structure tests pass (including new helmfile, vault, govc, yq tests)
- [ ] `ansible-galaxy collection list` shows `kubernetes.core` instead of `community.kubernetes`