### PR TITLE
feat: add community.hashi_vault collection

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,5 +3,7 @@ collections:
     version: 8.4.0
   - name: community.kubernetes
     version: 2.0.1
+  - name: community.hashi_vault
+    version: 7.1.0
   - name: community.vmware
     version: 6.2.0


### PR DESCRIPTION
## Summary

- Add `community.hashi_vault` 7.1.0 to Ansible collection requirements
- Enables Vault lookups and modules in Ansible playbooks