### PR TITLE
feat: add community.crypto collection

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,6 +3,8 @@ collections:
     version: 8.4.0
   - name: community.kubernetes
     version: 2.0.1
+  - name: community.crypto
+    version: 3.1.1
   - name: community.hashi_vault
     version: 7.1.0
   - name: community.vmware


### PR DESCRIPTION
Add community.crypto 3.1.1 for x509 certificates, openssl keys and ACME/Let's Encrypt modules.