### PR TITLE
feat: add ansible.posix, ansible.utils, community.general and community.crypto collections

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,8 @@
 collections:
   - name: ansible.netcommon
     version: 8.4.0
+  - name: ansible.posix
+    version: 2.1.0
   - name: community.hashi_vault
     version: 7.1.0
   - name: kubernetes.core

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,6 +5,8 @@ collections:
     version: 2.1.0
   - name: ansible.utils
     version: 6.0.1
+  - name: community.crypto
+    version: 3.1.1
   - name: community.general
     version: 12.5.0
   - name: community.hashi_vault

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,6 +3,8 @@ collections:
     version: 8.4.0
   - name: ansible.posix
     version: 2.1.0
+  - name: ansible.utils
+    version: 6.0.1
   - name: community.hashi_vault
     version: 7.1.0
   - name: kubernetes.core

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,6 +5,8 @@ collections:
     version: 2.1.0
   - name: ansible.utils
     version: 6.0.1
+  - name: community.general
+    version: 12.5.0
   - name: community.hashi_vault
     version: 7.1.0
   - name: kubernetes.core


### PR DESCRIPTION
## Summary

Add four new Ansible collections:

- **ansible.posix** 2.1.0 — sysctl, mount, selinux, authorized_key, synchronize
- **ansible.utils** 6.0.1 — ipaddr filters, validate plugin, network utilities
- **community.general** 12.5.0 — keycloak, ldap, nmcli, terraform and many more
- **community.crypto** 3.1.1 — x509 certificates, openssl keys, ACME/Let's Encrypt

Supersedes #115, #116, #117, #118.