### PR TITLE
chore(deps): update all dependencies to clear CVE scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       matrix: ${{ steps.channels.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Discover latest stable channels
         id: channels
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,15 @@ ARG OPENSHIFT_RELEASE
 ENV OPENSHIFT_RELEASE=${OPENSHIFT_RELEASE}
 
 # renovate: datasource=github-tags depName=helm/helm
-ARG HELM_RELEASE=4.1.3
+ARG HELM_RELEASE=4.2.4
 # renovate: datasource=github-tags depName=hashicorp/vault
-ARG VAULT_RELEASE=1.21.4
+ARG VAULT_RELEASE=2.0.4
 # renovate: datasource=github-tags depName=helmfile/helmfile
-ARG HELMFILE_RELEASE=1.4.3
+ARG HELMFILE_RELEASE=1.7.4
 # renovate: datasource=github-tags depName=vmware/govmomi
-ARG GOVC_RELEASE=0.53.0
+ARG GOVC_RELEASE=0.56.0
 # renovate: datasource=github-tags depName=mikefarah/yq
-ARG YQ_RELEASE=4.52.5
+ARG YQ_RELEASE=4.53.6
 
 RUN dnf -y install unzip
 
@@ -69,13 +69,13 @@ RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/subscription-manager.c
  && yum makecache --timer \
  && yum -y install initscripts \
  && yum -y update \
- && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+ && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
  && yum -y install \
       sudo \
       which \
       hostname \
-      python3.12 \
-      python3.12-pip \
+      python3.14 \
+      python3.14-pip \
       vim \
       git \
       wget \
@@ -94,7 +94,8 @@ RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/subscription-manager.c
 
 # Python Dependencies
 COPY requirements.txt /etc/requirements.txt
-RUN pip3.12 install --no-cache-dir -r /etc/requirements.txt
+RUN pip3.14 install --no-cache-dir --upgrade pip setuptools wheel \
+ && pip3.14 install --no-cache-dir -r /etc/requirements.txt
 
 # Ansible Collections
 COPY requirements.yml /etc/requirements.yml

--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,12 @@
   "extends": [
     "config:recommended"
   ],
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 0,
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^Dockerfile$"],
+      "managerFilePatterns": ["/^Dockerfile$/"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\nARG\\s+\\w+=(?<currentValue>[^\\s]+)"
       ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-ansible==13.5.0
+ansible==14.3.1
 dnspython==2.8.0
-pyvmomi==9.0.0.0
+pyvmomi==9.1.0.0
 netaddr==1.3.0
-requests==2.33.1
-kubernetes==35.0.0
+requests==2.34.2
+kubernetes==36.0.3
 PyYAML==6.0.3
 jsonpatch==1.33

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,17 +1,17 @@
 collections:
   - name: ansible.netcommon
-    version: 8.4.0
+    version: 8.6.2
   - name: ansible.posix
-    version: 2.1.0
+    version: 2.2.2
   - name: ansible.utils
-    version: 6.0.1
+    version: 6.1.0
   - name: community.crypto
-    version: 3.1.1
+    version: 3.3.0
   - name: community.general
-    version: 12.5.0
+    version: 13.3.0
   - name: community.hashi_vault
     version: 7.1.0
   - name: kubernetes.core
-    version: 6.3.0
+    version: 6.5.0
   - name: community.vmware
-    version: 6.2.0
+    version: 6.2.1


### PR DESCRIPTION
Rolls up every pending dependency update into a single change, driven by the
image failing a customer CVE scan. Supersedes the ten open Renovate PRs
(#120-#129) plus the nine updates that were sitting rate-limited in the
dependency dashboard (#105).

## Scan impact

Measured with `grype` against `quay.io/slauger/openshift-sdk:4.22.10`
(current published image) versus a local build of this branch:

| Severity | Before | After  |
| -------- | -----: | -----: |
| Critical |     33 |      0 |
| High     |    378 |    184 |
| Medium   |    653 |    499 |
| Low      |    640 |    628 |

All 33 criticals are gone. They came from the vendored Go binaries, mostly
outdated `golang.org/x/crypto` and `jackc/pgx`.

Critical + High per binary:

| Binary              | Before | After |
| ------------------- | -----: | ----: |
| helmfile            |     74 |    31 |
| vault               |     72 |    15 |
| helm                |     56 |    15 |
| yq                  |     45 |     0 |
| govc                |     41 |     0 |
| oc / kubectl        |  31/31 | 31/31 |
| openshift-install   |     24 |    24 |

## Changes

**Bundled tools** (`Dockerfile`)

- helm 4.1.3 -> 4.2.4
- vault 1.21.4 -> 2.0.4
- helmfile 1.4.3 -> 1.7.4
- govc 0.53.0 -> 0.56.0
- yq 4.52.5 -> 4.53.6

**Python** (`requirements.txt`)

- ansible 13.5.0 -> 14.3.1 (ansible-core 2.21.3)
- pyvmomi 9.0.0.0 -> 9.1.0.0
- requests 2.33.1 -> 2.34.2
- kubernetes 35.0.0 -> 36.0.3

**Ansible collections** (`requirements.yml`)

- ansible.netcommon 8.4.0 -> 8.6.2
- ansible.posix 2.1.0 -> 2.2.2
- ansible.utils 6.0.1 -> 6.1.0
- community.crypto 3.1.1 -> 3.3.0
- community.general 12.5.0 -> 13.3.0
- kubernetes.core 6.3.0 -> 6.5.0
- community.vmware 6.2.0 -> 6.2.1

**Python 3.12 -> 3.14**

UBI9 AppStream ships python3.14 (3.14.7). Beyond being current, this
replaces the pip 23.2.1 / setuptools 68.2.2 that come with the 3.12 stack
and that scanners routinely flag. The image now has pip 26.2.1 and
setuptools 84.0.0, and pip/setuptools/wheel are explicitly upgraded before
requirements are installed.

ansible-core 2.21 declares support for 3.14, and every pinned dependency has
a cp314 or pure-python wheel, so nothing is built from source.

**EPEL 8 -> EPEL 9 (bug fix)**

The image is built on UBI9 but installed `epel-release-latest-8`. It was
pulling el8 builds (`pwgen`, `libcbor`) onto an el9 base, and the el8-only
modular repos were enabled. Now on EPEL 9; `libcbor` is gone and `pwgen`
comes from the matching release.

**CI and Renovate**

- actions/checkout v6 -> v7
- Custom manager migrated from the deprecated `fileMatch` to
  `managerFilePatterns`
- `prConcurrentLimit` raised to 20 and the hourly limit dropped. The default
  of 10 was the reason nine updates never became PRs and the backlog built up
  unnoticed.

## Breaking changes to review

- **vault 1.21.4 -> 2.0.4** is a major. Only the CLI ships here and 1.21.4 is
  the last CE 1.x release, so there is no patch path within 1.x. This bump
  alone clears 57 critical/high findings.
- **ansible 13 -> 14**, **community.general 12 -> 13**, **kubernetes 35 -> 36**
  are majors. Verify any playbooks consuming this image.

## Verification

Built locally for `linux/amd64` against OpenShift 4.22.10. All 10
container-structure-tests pass. Runtime spot check confirms Python 3.14.7,
ansible-core 2.21.3, all eight collections at their target versions, and EPEL 9
repos only.

## Not addressed

The 37 remaining High findings from RPMs are all `not-fixed` upstream, so no
UBI9 update clears them today. Two optional levers if the customer scanner
still blocks:

- `vim` accounts for 16 of the 37 (4 CVEs across 4 subpackages). Dropping it
  is a usability regression for an interactive SDK image.
- `openssl-devel` and `libffi-devel` are build-only dependencies that could
  move to a builder stage rather than shipping.

Both are behaviour changes, so they are left out of this PR.

The remaining findings on `oc`, `kubectl` and `openshift-install` are tied to
the OpenShift release being packaged and cannot be fixed here. `helmfile`,
`helm` and `vault` are already at the newest upstream release.
