### PR TITLE
ci: lint pull requests to unblock renovate automerge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,46 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+# Supersede outdated runs on the same ref; a lint run is cheap but pointless
+# once a newer commit exists.
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.5.0
+        with:
+          dockerfile: Dockerfile
+          config: .hadolint.yaml
+
+      - name: Lint workflows
+        uses: docker://rhysd/actionlint:1.7.12
+
+      - name: Lint YAML
+        run: |
+          pipx install yamllint
+          yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: {check-keys: false}}}' \
+            requirements.yml tests/image.tests.yaml .hadolint.yaml .github/workflows/
+
+      - name: Validate renovate.json
+        run: python3 -m json.tool renovate.json > /dev/null
+
+      - name: Check discover_versions.py
+        run: python3 -m compileall -q scripts/discover_versions.py

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -2,4 +2,6 @@ ignored:
   - DL3045
   - DL3013
   - DL3003
+  # Pinning RPM versions would defeat the point of rebuilding for CVE fixes.
   - DL3033
+  - DL3041

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi AS unarchive
+FROM registry.access.redhat.com/ubi9/ubi:9.8 AS unarchive
 
 ARG OPENSHIFT_RELEASE
 ENV OPENSHIFT_RELEASE=${OPENSHIFT_RELEASE}
@@ -14,7 +14,7 @@ ARG GOVC_RELEASE=0.56.0
 # renovate: datasource=github-tags depName=mikefarah/yq
 ARG YQ_RELEASE=4.53.6
 
-RUN dnf -y install unzip
+RUN dnf -y install unzip && dnf clean all
 
 COPY openshift-install-linux-${OPENSHIFT_RELEASE}.tar.gz .
 COPY openshift-client-linux-${OPENSHIFT_RELEASE}.tar.gz .
@@ -57,7 +57,7 @@ RUN curl -vfLO https://github.com/vmware/govmomi/releases/download/v${GOVC_RELEA
 RUN curl -vfLo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_RELEASE}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq
 
-FROM registry.access.redhat.com/ubi9/ubi
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 
 LABEL maintainer="simon@lauger.de"
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^Dockerfile$/"],
+      "managerFilePatterns": [
+        "/^Dockerfile$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\nARG\\s+\\w+=(?<currentValue>[^\\s]+)"
       ],
@@ -17,9 +19,21 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["custom.regex"],
-      "matchFileNames": ["Dockerfile"],
+      "description": "Automerge non-major updates across every manager once the PR build is green",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin"
+      ],
       "automerge": true
+    },
+    {
+      "description": "Major updates stay manual - ansible 13->14 and community.general 12->13 both needed review",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #130. Makes Renovate automerge actually work, and widens it to
cover every dependency in the repository instead of just the Dockerfile ARGs.

## Why automerge never fired

Two independent blockers, both confirmed against the API:

1. **Pull requests had no status checks.** The build workflow only triggered
   on `push` to master and on the nightly schedule, so every Renovate PR sat
   at `checks: 0`. Renovate reads an empty check set as a *pending* branch
   status and will not automerge a branch that is not green. The four
   Dockerfile PRs already had `automerge: true` and still sat open from April
   to August for exactly this reason.
2. **`allow_auto_merge` was `false` on the repository**, so Renovate's
   platform automerge had nothing to arm.

`master` also has no branch protection, so nothing was enforcing checks
either way.

## Lint, not build

The gate is a lint-only workflow. Building the image on every dependency bump
would cost far more Actions minutes than it is worth, and the nightly schedule
already builds and tests all three supported releases. Renovate only needs a
green check to automerge, not a full integration test.

New `.github/workflows/lint.yml`, one job, no matrix:

- **hadolint** on the Dockerfile, using the existing `.hadolint.yaml`
- **actionlint** on the workflows, pinned to `docker://rhysd/actionlint:1.7.12`
- **yamllint** on `requirements.yml`, the tests and the workflows
- JSON validation of `renovate.json`
- syntax check of `scripts/discover_versions.py`

`requirements.yml` and `renovate.json` are exactly the files Renovate edits, so
a malformed update gets caught.

## Dockerfile fixes hadolint required

hadolint failed on the existing Dockerfile with four findings, so a gate would
have been red from day one:

- **DL3006** on both `FROM` lines: the base image was untagged. Now pinned to
  `ubi9/ubi:9.8`. That is the same digest `latest` resolves to today
  (`sha256:03b3d228...`), so the image content does not change. It also means
  Renovate can finally track the base image; the dockerfile manager reported
  zero dependencies while the `FROM` was untagged.
- **DL3040**: missing `dnf clean all` in the unarchive stage. Added.
- **DL3041**: asks for pinned RPM versions. Ignored, alongside the DL3033 that
  was already ignored. Both work against rebuilding to pick up CVE fixes.

## Automerge coverage

The old rule was scoped to `custom.regex` on the Dockerfile only. It now
applies to all managers, so pip requirements, galaxy collections, GitHub
Actions and the Dockerfile ARGs are all covered:

- `minor`, `patch`, `digest`, `pin` -> automerge once lint is green
- `major` -> stays manual

Majors are deliberately excluded. In #130 both ansible 13 -> 14 and
community.general 12 -> 13 were genuine breaking changes.

## Repository settings

Applied out of band, not part of this diff:

- `allow_auto_merge` enabled
- `delete_branch_on_merge` enabled, so automerged branches clean themselves up

## Verification

Every lint step was run locally against this branch before pushing:

| Check | Result |
| ----- | ------ |
| hadolint (with `.hadolint.yaml`) | exit 0 |
| actionlint | exit 0 |
| yamllint | exit 0 |
| `renovate.json` JSON | valid |
| `discover_versions.py` | compiles |

`ubi9/ubi:9.8` and `ubi9/ubi:latest` confirmed to be the same digest.

## Trade-off worth knowing

A lint gate does not prove that a bumped version actually builds and installs.
An automerged update that breaks the image would be caught by the nightly
build rather than at merge time. That is the cost of not spending build
minutes per PR. If you would rather catch it at merge time, the middle ground
is building only when `Dockerfile` or `requirements*` change, on a single
release.

## Optional hardening, left out

- **`minimumReleaseAge`** (e.g. 3 days) would stop automerge picking up a
  version published minutes ago, the usual defence against a compromised
  upstream release. It costs some speed on CVE fixes, so it is your call.
- **Branch protection on master** requiring the lint check. It would also mean
  your own direct pushes to master go through PRs, so I did not impose it.
