### PR TITLE
feat: add operator, virtualization and day-2 CLIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,26 @@ ARG HELMFILE_RELEASE=1.7.4
 ARG GOVC_RELEASE=0.56.0
 # renovate: datasource=github-tags depName=mikefarah/yq
 ARG YQ_RELEASE=4.53.6
+# renovate: datasource=github-tags depName=stern/stern
+ARG STERN_RELEASE=1.34.0
+# renovate: datasource=github-tags depName=ahmetb/kubectx
+ARG KUBECTX_RELEASE=0.11.0
+# renovate: datasource=github-tags depName=tektoncd/cli
+ARG TKN_RELEASE=0.46.0
+# renovate: datasource=github-tags depName=knative/client
+ARG KN_RELEASE=1.23.0
+# renovate: datasource=github-tags depName=argoproj/argo-cd
+ARG ARGOCD_RELEASE=3.5.2
+# renovate: datasource=github-tags depName=kubevirt/kubevirt
+ARG KUBEVIRT_RELEASE=1.9.0
+# renovate: datasource=github-tags depName=yaacov/kubectl-mtv
+ARG KUBECTL_MTV_RELEASE=0.3.31
+# renovate: datasource=github-tags depName=velero-io/velero
+ARG VELERO_RELEASE=1.18.2
+# renovate: datasource=github-tags depName=migtools/oadp-cli
+ARG KUBECTL_OADP_RELEASE=0.3.3
+# renovate: datasource=github-tags depName=stackrox/stackrox
+ARG ROXCTL_RELEASE=4.11.3
 
 RUN dnf -y install unzip && dnf clean all
 
@@ -22,10 +42,8 @@ COPY openshift-client-linux-${OPENSHIFT_RELEASE}.tar.gz .
 # OpenShift Binaries
 RUN tar vxzf openshift-install-linux-${OPENSHIFT_RELEASE}.tar.gz openshift-install && \
     tar vxzf openshift-client-linux-${OPENSHIFT_RELEASE}.tar.gz oc && \
-    tar vxzf openshift-client-linux-${OPENSHIFT_RELEASE}.tar.gz kubectl && \
     mv openshift-install /usr/local/bin/openshift-install && \
     mv oc /usr/local/bin/oc && \
-    mv kubectl /usr/local/bin/kubectl && \
     rm openshift-install-linux-${OPENSHIFT_RELEASE}.tar.gz && \
     rm openshift-client-linux-${OPENSHIFT_RELEASE}.tar.gz
 
@@ -57,6 +75,71 @@ RUN curl -vfLO https://github.com/vmware/govmomi/releases/download/v${GOVC_RELEA
 RUN curl -vfLo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_RELEASE}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq
 
+# stern Binary
+RUN curl -vfLO https://github.com/stern/stern/releases/download/v${STERN_RELEASE}/stern_${STERN_RELEASE}_linux_amd64.tar.gz && \
+    tar vxzf stern_${STERN_RELEASE}_linux_amd64.tar.gz stern && \
+    mv stern /usr/local/bin/stern && \
+    rm stern_${STERN_RELEASE}_linux_amd64.tar.gz
+
+# kubectx and kubens Binaries
+RUN curl -vfLO https://github.com/ahmetb/kubectx/releases/download/v${KUBECTX_RELEASE}/kubectx_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz && \
+    curl -vfLO https://github.com/ahmetb/kubectx/releases/download/v${KUBECTX_RELEASE}/kubens_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz && \
+    tar vxzf kubectx_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz kubectx && \
+    tar vxzf kubens_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz kubens && \
+    mv kubectx kubens /usr/local/bin/ && \
+    rm kubectx_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz kubens_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz
+
+# tkn Binary (OpenShift Pipelines)
+RUN curl -vfLO https://github.com/tektoncd/cli/releases/download/v${TKN_RELEASE}/tkn_${TKN_RELEASE}_Linux_x86_64.tar.gz && \
+    tar vxzf tkn_${TKN_RELEASE}_Linux_x86_64.tar.gz tkn && \
+    mv tkn /usr/local/bin/tkn && \
+    rm tkn_${TKN_RELEASE}_Linux_x86_64.tar.gz
+
+# kn Binary (OpenShift Serverless)
+RUN curl -vfLo /usr/local/bin/kn https://github.com/knative/client/releases/download/knative-v${KN_RELEASE}/kn-linux-amd64 && \
+    chmod +x /usr/local/bin/kn
+
+# argocd Binary (OpenShift GitOps)
+RUN curl -vfLo /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v${ARGOCD_RELEASE}/argocd-linux-amd64 && \
+    chmod +x /usr/local/bin/argocd
+
+# virtctl Binary (OpenShift Virtualization)
+RUN curl -vfLo /usr/local/bin/virtctl https://github.com/kubevirt/kubevirt/releases/download/v${KUBEVIRT_RELEASE}/virtctl-v${KUBEVIRT_RELEASE}-linux-amd64 && \
+    chmod +x /usr/local/bin/virtctl
+
+# kubectl-mtv Binary (Migration Toolkit for Virtualization)
+RUN curl -vfLO https://github.com/yaacov/kubectl-mtv/releases/download/v${KUBECTL_MTV_RELEASE}/kubectl-mtv-v${KUBECTL_MTV_RELEASE}-linux-amd64.tar.gz && \
+    tar vxzf kubectl-mtv-v${KUBECTL_MTV_RELEASE}-linux-amd64.tar.gz kubectl-mtv-linux-amd64 && \
+    mv kubectl-mtv-linux-amd64 /usr/local/bin/kubectl-mtv && \
+    rm kubectl-mtv-v${KUBECTL_MTV_RELEASE}-linux-amd64.tar.gz
+
+# velero Binary (OADP)
+RUN curl -vfLO https://github.com/velero-io/velero/releases/download/v${VELERO_RELEASE}/velero-v${VELERO_RELEASE}-linux-amd64.tar.gz && \
+    tar vxzf velero-v${VELERO_RELEASE}-linux-amd64.tar.gz velero-v${VELERO_RELEASE}-linux-amd64/velero && \
+    mv velero-v${VELERO_RELEASE}-linux-amd64/velero /usr/local/bin/velero && \
+    rm -r velero-v${VELERO_RELEASE}-linux-amd64.tar.gz velero-v${VELERO_RELEASE}-linux-amd64
+
+# kubectl-oadp Binary (OADP)
+RUN curl -vfLO https://github.com/migtools/oadp-cli/releases/download/v${KUBECTL_OADP_RELEASE}/kubectl-oadp_v${KUBECTL_OADP_RELEASE}_linux_amd64.tar.gz && \
+    tar vxzf kubectl-oadp_v${KUBECTL_OADP_RELEASE}_linux_amd64.tar.gz kubectl-oadp && \
+    mv kubectl-oadp /usr/local/bin/kubectl-oadp && \
+    rm kubectl-oadp_v${KUBECTL_OADP_RELEASE}_linux_amd64.tar.gz
+
+# roxctl Binary (Advanced Cluster Security)
+RUN curl -vfLo /usr/local/bin/roxctl https://mirror.openshift.com/pub/rhacs/assets/${ROXCTL_RELEASE}/bin/Linux/roxctl && \
+    chmod +x /usr/local/bin/roxctl
+
+# oc-mirror Binary, version matched to the release, stable channel as fallback for OKD
+RUN { curl -vfLO https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OPENSHIFT_RELEASE}/oc-mirror.rhel9.tar.gz || \
+      curl -vfLO https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/oc-mirror.rhel9.tar.gz; } && \
+    tar vxzf oc-mirror.rhel9.tar.gz oc-mirror && \
+    mv oc-mirror /usr/local/bin/oc-mirror && \
+    chmod 0755 /usr/local/bin/oc-mirror && \
+    rm oc-mirror.rhel9.tar.gz
+
+# hcp is only published inside the HyperShift operator image, so we lift it out of there
+FROM quay.io/hypershift/hypershift-operator@sha256:f45e8a0e1f646fb95699bf48fd4dc693657dcf2cf961339a32240d08a413bb43 AS hypershift
+
 FROM registry.access.redhat.com/ubi9/ubi:9.8-1787634763
 
 LABEL maintainer="simon@lauger.de"
@@ -66,6 +149,7 @@ ENV OPENSHIFT_RELEASE=${OPENSHIFT_RELEASE}
 
 # Install requirements.
 RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/subscription-manager.conf \
+ && echo 'tsflags=nodocs' >> /etc/dnf/dnf.conf \
  && yum makecache --timer \
  && yum -y install initscripts \
  && yum -y update \
@@ -82,6 +166,7 @@ RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/subscription-manager.c
       jq \
       pwgen \
       unzip \
+      bash-completion \
       bind-utils \
       ca-certificates \
       openssh \
@@ -90,7 +175,7 @@ RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/subscription-manager.c
       openssl-devel \
       libffi-devel \
  && yum clean all \
- && rm -rf /var/cache/dnf/*
+ && rm -rf /var/cache/dnf/* /usr/share/doc/* /usr/share/man/*
 
 # Python Dependencies
 COPY requirements.txt /etc/requirements.txt
@@ -102,11 +187,18 @@ COPY requirements.yml /etc/requirements.yml
 RUN ansible-galaxy collection install -r /etc/requirements.yml
 
 # OpenShift Tools
-COPY --from=unarchive /usr/local/bin/oc usr/local/bin/kubectl /usr/local/bin/openshift-install /usr/local/bin/
+COPY --from=unarchive /usr/local/bin/oc /usr/local/bin/openshift-install /usr/local/bin/oc-mirror /usr/local/bin/
+
+# OpenShift Operator CLIs
+COPY --from=unarchive /usr/local/bin/tkn /usr/local/bin/kn /usr/local/bin/argocd /usr/local/bin/roxctl /usr/local/bin/
+COPY --from=unarchive /usr/local/bin/virtctl /usr/local/bin/kubectl-mtv /usr/local/bin/velero /usr/local/bin/kubectl-oadp /usr/local/bin/
+COPY --from=hypershift /usr/bin/hcp /usr/local/bin/hcp
 
 # External tools
-COPY --from=unarchive /usr/local/bin/helm /usr/local/bin/helmfile /usr/local/bin/vault /usr/local/bin/govc /usr/local/bin/yq /usr/local/bin/
+COPY --from=unarchive /usr/local/bin/helm /usr/local/bin/helmfile /usr/local/bin/vault /usr/local/bin/govc /usr/local/bin/yq /usr/local/bin/stern /usr/local/bin/kubectx /usr/local/bin/kubens /usr/local/bin/
 
-# Create workspace
-RUN mkdir /workspace
+# oc ships kubectl as a byte identical copy, a symlink keeps the behaviour and saves the space
+RUN ln -s oc /usr/local/bin/kubectl \
+ && oc completion bash > /etc/bash_completion.d/oc \
+ && mkdir /workspace
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -10,12 +10,23 @@ All-in-one container image for OpenShift CI/CD pipelines. Based on Red Hat UBI 9
 |------|-------------|
 | `openshift-install` | OpenShift cluster installer |
 | `oc` / `kubectl` | OpenShift and Kubernetes CLI |
-| `ansible` | Automation engine with `kubernetes.core`, `ansible.netcommon` and `community.vmware` collections |
+| `ansible` | Automation engine with the collections pinned in `requirements.yml`, including `kubernetes.core`, `kubevirt.core` and `community.vmware` |
 | `helm` | Kubernetes package manager |
 | `helmfile` | Declarative Helm chart management |
 | `vault` | HashiCorp Vault CLI |
 | `govc` | VMware vSphere CLI |
 | `yq` | YAML/JSON/XML processor |
+| `oc-mirror` | Mirroring of releases and Operators for disconnected installs |
+| `virtctl` | OpenShift Virtualization / KubeVirt CLI |
+| `kubectl-mtv` | Migration Toolkit for Virtualization CLI (`oc mtv`) |
+| `velero` / `kubectl-oadp` | Backup and restore via OADP (`oc oadp`) |
+| `tkn` | OpenShift Pipelines (Tekton) CLI |
+| `kn` | OpenShift Serverless (Knative) CLI |
+| `argocd` | OpenShift GitOps (Argo CD) CLI |
+| `roxctl` | Advanced Cluster Security CLI |
+| `hcp` | Hosted Control Planes (HyperShift) CLI |
+| `stern` | Multi-pod log tailing |
+| `kubectx` / `kubens` | Fast context and namespace switching |
 
 ## 🚀 Quick Start
 
@@ -30,6 +41,8 @@ podman run -it quay.io/slauger/openshift-sdk:4.21.3
 ```
 
 The image tag corresponds to the OpenShift release version.
+
+Bash completion for `oc` is preinstalled in `/etc/bash_completion.d/oc`.
 
 ## 🔄 Automated Builds
 

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,13 @@
   ],
   "packageRules": [
     {
+      "description": "knative/client tags are prefixed with knative-v, strip it so the ARG stays a plain version",
+      "matchDepNames": [
+        "knative/client"
+      ],
+      "extractVersion": "^knative-v(?<version>.+)$"
+    },
+    {
       "description": "Automerge non-major updates across every manager once the PR build is green",
       "matchUpdateTypes": [
         "minor",

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,5 +13,7 @@ collections:
     version: 7.1.0
   - name: kubernetes.core
     version: 6.5.0
+  - name: kubevirt.core
+    version: 2.3.0
   - name: community.vmware
     version: 6.2.1

--- a/tests/image.tests.yaml
+++ b/tests/image.tests.yaml
@@ -32,3 +32,45 @@ commandTests:
   - name: "yq exists"
     command: "yq"
     args: ["--version"]
+  - name: "stern exists"
+    command: "stern"
+    args: ["--version"]
+  - name: "kubectx exists"
+    command: "kubectx"
+    args: ["--version"]
+  - name: "kubens exists"
+    command: "kubens"
+    args: ["--version"]
+  - name: "tkn exists"
+    command: "tkn"
+    args: ["version"]
+  - name: "kn exists"
+    command: "kn"
+    args: ["version"]
+  - name: "argocd exists"
+    command: "argocd"
+    args: ["version", "--client"]
+  - name: "virtctl exists"
+    command: "virtctl"
+    args: ["version", "--client"]
+  - name: "kubectl-mtv exists"
+    command: "kubectl-mtv"
+    args: ["version"]
+  - name: "velero exists"
+    command: "velero"
+    args: ["version", "--client-only"]
+  - name: "kubectl-oadp exists"
+    command: "kubectl-oadp"
+    args: ["version", "--client-only"]
+  - name: "roxctl exists"
+    command: "roxctl"
+    args: ["version"]
+  - name: "hcp exists"
+    command: "hcp"
+    args: ["version", "--client-only"]
+  - name: "oc-mirror exists"
+    command: "oc-mirror"
+    args: ["--v2", "--version"]
+  - name: "oc bash completion is registered"
+    command: "bash"
+    args: ["-c", "source /etc/bash_completion.d/oc && complete -p oc"]


### PR DESCRIPTION
## Was drin ist

13 zusätzliche CLIs, alle über `ARG` + renovate-Kommentar gepinnt:

| Tool | Zweck | Quelle |
|---|---|---|
| `virtctl` | OpenShift Virtualization | kubevirt/kubevirt 1.9.0 |
| `kubectl-mtv` | Migration Toolkit for Virtualization (`oc mtv`) | yaacov/kubectl-mtv 0.3.31 |
| `velero` / `kubectl-oadp` | Backup und Restore via OADP (`oc oadp`) | velero-io/velero 1.18.2, migtools/oadp-cli 0.3.3 |
| `tkn` | OpenShift Pipelines | tektoncd/cli 0.46.0 |
| `kn` | OpenShift Serverless | knative/client 1.23.0 |
| `argocd` | OpenShift GitOps | argoproj/argo-cd 3.5.2 |
| `roxctl` | Advanced Cluster Security | mirror.openshift.com/pub/rhacs 4.11.3 |
| `hcp` | Hosted Control Planes | HyperShift-Operator-Image, digest-gepinnt |
| `oc-mirror` | Disconnected Mirroring | mirror.openshift.com, releasegleich |
| `stern`, `kubectx`, `kubens` | Alltag | 1.34.0 / 0.11.0 |

Dazu die `oc`-Bash-Completion fest im Image (`/etc/bash_completion.d/oc`) und `kubevirt.core` 2.3.0 in `requirements.yml`.

## Entscheidungen, die Review verdienen

**`oc-mirror`** gibt es nicht auf GitHub. Wird versionsgleich aus `clients/ocp/${OPENSHIFT_RELEASE}/` geholt, mit Fallback auf `clients/ocp/stable/` — nötig, weil OKD-Versionen (`4.21.0-okd-scos.0`) auf dem OCP-Mirror 404 liefern.

**`hcp`** wird nirgends als Binary veröffentlicht, nur im HyperShift-Operator-Image. Kommt daher aus einer digest-gepinnten Stage. Das ist der Community-Build; die supportete Variante läge in `registry.redhat.io/multicluster-engine/` und bräuchte ein Pull-Secret im Build.

**`tkn` / `kn`** kommen von upstream statt aus den `pipelines`- und `serverless`-Verzeichnissen des Mirrors: gleiche Binaries, aber nur upstream-Tags kann renovate pinnen und automergen.

## Größe

Netto wächst das Image um ~1,2 GB auf **4,06 GB** (Registry-Transfer ~1,6 GiB). Gegengerechnet sind dabei 170 MB, die beim Anfassen der Datei aufgefallen sind:

- `kubectl` war eine byte-identische Kopie von `oc` und wurde zweimal ausgeliefert (`md5sum` identisch) — jetzt ein Symlink, `oc` schaltet über `argv[0]` in den kubectl-Modus. −134 MB
- `tsflags=nodocs` plus Aufräumen der Basis-Doku. −36 MB, `/usr/share/licenses` bleibt

Die dicksten Posten bleiben `openshift-install` (657 MB), `vault` (513 MB) und `oc-mirror` (301 MB).

## Verifikation

- hadolint mit `.hadolint.yaml`, yamllint und `python3 -m json.tool` sauber
- Vollständiger `docker build --platform linux/amd64` gegen 4.21.29 erfolgreich
- `container-structure-test`: **24/24 PASS**. Jedes neue Tool mit einem Version-Kommando, das ohne Cluster durchläuft; die Flags wurden vorher einzeln geprüft (`velero version --client-only`, `hcp version --client-only`, `oc-mirror --v2 --version` — ohne die Flags brechen `kubectl-oadp` und `oc-mirror` ab). Die Completion wird gesourced und `complete -p oc` geprüft.
- Im gebauten Image verifiziert, dass `kubevirt.core` als 2.3.0 auflöst und `kubectl` über den Symlink die kubectl-Ausgabe liefert

## Offen gelassen

`ansible` schleppt 94 Collections mit (436 MB), von denen wir 9 pinnen (49 MB). Ein Wechsel auf `ansible-core` spart ~387 MB, nimmt Nutzern des Images aber alles weg, was nicht in `requirements.yml` steht — bewusst nicht Teil dieses PRs.
