### PR TITLE
fix: track roxctl via github-releases instead of github-tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ARG KUBECTL_MTV_RELEASE=0.3.31
 ARG VELERO_RELEASE=1.18.2
 # renovate: datasource=github-tags depName=migtools/oadp-cli
 ARG KUBECTL_OADP_RELEASE=0.3.3
-# renovate: datasource=github-tags depName=stackrox/stackrox
+# renovate: datasource=github-releases depName=stackrox/stackrox
 ARG ROXCTL_RELEASE=4.11.3
 
 RUN dnf -y install unzip && dnf clean all


### PR DESCRIPTION
Behebt die Ursache von #134.

## Was schiefgelaufen ist

`stackrox/stackrox` hat einen vermüllten Tag-Namensraum. Neben den echten Versionen liegen dort unter anderem:

```
134
9.9.99-rc-9
9.x  8.x  7.x  6.x
test-nightly-tag, test-notnightly-tag, check-rebuilding, gj-test-tag, …
```

Mit `datasource=github-tags` ist `134` damit die höchste Version — genau das hat #134 vorgeschlagen. Die daraus gebaute URL

```
https://mirror.openshift.com/pub/rhacs/assets/134/bin/Linux/roxctl
```

existiert nicht, der Build wäre auf `curl -f` gelaufen. Das war meine falsche Datasource-Wahl in #133, kein Renovate-Fehler.

## Fix

`datasource=github-releases` für diesen einen ARG. Die Releases desselben Repos sind sauber:

| Release | Datum | prerelease |
|---|---|---|
| 4.11.3 | 2026-08-24 | nein |
| 4.10.7 | 2026-08-24 | nein |
| 4.11.3-rc.4 | 2026-08-18 | ja |

Release Candidates sind als prerelease markiert und werden von Renovate ohnehin gefiltert. Der custom manager in `renovate.json` fängt die Zeile unverändert ab, `datasource` ist dort ein Capture-Group.

## Gegenprüfung

Für alle 15 gepinnten Repos den höchsten parsebaren Tag gegen den Pin verglichen:

```
stackrox/stackrox        pin=4.11.3   höchste Tags: 134.0.0, 9.0.0, 8.0.0  <== HÖHER ALS PIN
stern/stern              pin=1.34.0   höchste Tags: 1.34.0, 1.33.1, 1.33.0
kubevirt/kubevirt        pin=1.9.0    höchste Tags: 1.9.0, 1.8.4, 1.8.3
…
```

stackrox ist der einzige Fall. `mikefarah/yq` hat `vTestA`/`vTestB`, die parsen aber nicht als Version und werden ignoriert.

hadolint ist sauber. Kein Rebuild nötig, die Änderung betrifft nur den Kommentar, den Renovate liest — `ROXCTL_RELEASE` bleibt auf 4.11.3.
