### PR TITLE
feat: ship bash completion for every tool that provides one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,10 @@ RUN curl -vfLO https://github.com/ahmetb/kubectx/releases/download/v${KUBECTX_RE
     tar vxzf kubectx_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz kubectx && \
     tar vxzf kubens_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz kubens && \
     mv kubectx kubens /usr/local/bin/ && \
-    rm kubectx_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz kubens_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz
+    rm kubectx_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz kubens_v${KUBECTX_RELEASE}_linux_x86_64.tar.gz && \
+    mkdir /completions && \
+    curl -vfLo /completions/kubectx https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_RELEASE}/completion/kubectx.bash && \
+    curl -vfLo /completions/kubens https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_RELEASE}/completion/kubens.bash
 
 # tkn Binary (OpenShift Pipelines)
 RUN curl -vfLO https://github.com/tektoncd/cli/releases/download/v${TKN_RELEASE}/tkn_${TKN_RELEASE}_Linux_x86_64.tar.gz && \
@@ -197,8 +200,21 @@ COPY --from=hypershift /usr/bin/hcp /usr/local/bin/hcp
 # External tools
 COPY --from=unarchive /usr/local/bin/helm /usr/local/bin/helmfile /usr/local/bin/vault /usr/local/bin/govc /usr/local/bin/yq /usr/local/bin/stern /usr/local/bin/kubectx /usr/local/bin/kubens /usr/local/bin/
 
-# oc ships kubectl as a byte identical copy, a symlink keeps the behaviour and saves the space
+# kubectx and kubens carry their completion in the repository, not in the binary
+COPY --from=unarchive /completions/ /etc/bash_completion.d/
+
+# oc ships kubectl as a byte identical copy, a symlink keeps the behaviour and saves the space.
+# Completions come from the binaries themselves, with four exceptions: oc-mirror insists on
+# --v2, stern and yq spell the subcommand differently, and vault expects the C mode that its
+# -autocomplete-install would wire into a dotfile. govc has no completion at all and the one
+# of kubectl-oadp blocks on a cluster connection, so both are left out.
 RUN ln -s oc /usr/local/bin/kubectl \
- && oc completion bash > /etc/bash_completion.d/oc \
+ && for tool in oc kubectl openshift-install helm helmfile tkn kn argocd velero virtctl roxctl hcp kubectl-mtv; do \
+        "$tool" completion bash > "/etc/bash_completion.d/$tool"; \
+    done \
+ && oc-mirror completion bash --v2 > /etc/bash_completion.d/oc-mirror \
+ && stern --completion bash > /etc/bash_completion.d/stern \
+ && yq shell-completion bash > /etc/bash_completion.d/yq \
+ && echo 'complete -C /usr/local/bin/vault vault' > /etc/bash_completion.d/vault \
  && mkdir /workspace
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ podman run -it quay.io/slauger/openshift-sdk:4.21.3
 
 The image tag corresponds to the OpenShift release version.
 
-Bash completion for `oc` is preinstalled in `/etc/bash_completion.d/oc`.
+Bash completion is preinstalled in `/etc/bash_completion.d/` for every tool that ships one, `oc` and `kubectl` included. It loads automatically in interactive shells.
 
 ## 🔄 Automated Builds
 

--- a/tests/image.tests.yaml
+++ b/tests/image.tests.yaml
@@ -74,3 +74,18 @@ commandTests:
   - name: "oc bash completion is registered"
     command: "bash"
     args: ["-c", "source /etc/bash_completion.d/oc && complete -p oc"]
+  - name: "kubectl bash completion is registered"
+    command: "bash"
+    args: ["-c", "source /etc/bash_completion.d/kubectl && complete -p kubectl"]
+  - name: "virtctl bash completion is registered"
+    command: "bash"
+    args: ["-c", "source /etc/bash_completion.d/virtctl && complete -p virtctl"]
+  - name: "vault bash completion is registered"
+    command: "bash"
+    args: ["-c", "source /etc/bash_completion.d/vault && complete -p vault"]
+  - name: "kubectx bash completion is registered"
+    command: "bash"
+    args: ["-c", "source /etc/bash_completion.d/kubectx && complete -p kubectx"]
+  - name: "every completion loads in an interactive shell"
+    command: "bash"
+    args: ["-ic", "for t in oc kubectl openshift-install helm helmfile tkn kn argocd velero virtctl roxctl hcp kubectl-mtv oc-mirror stern yq vault kubectx kubens; do complete -p $t > /dev/null || { echo missing completion: $t; exit 1; }; done"]


### PR DESCRIPTION
Bisher hatte nur `oc` eine Completion, obwohl `kubectl` dasselbe Binary ist und die meisten anderen CLIs eine erzeugen können.

## Was jetzt eine Completion hat

`completion bash` direkt aus dem Binary:

`oc`, `kubectl`, `openshift-install`, `helm`, `helmfile`, `tkn`, `kn`, `argocd`, `velero`, `virtctl`, `roxctl`, `hcp`, `kubectl-mtv`

Abweichender Aufruf:

| Tool | Aufruf | Grund |
|---|---|---|
| `oc-mirror` | `completion bash --v2` | bricht ohne `--v2` mit rc=255 ab |
| `stern` | `--completion bash` | kein Subkommando |
| `yq` | `shell-completion bash` | eigener Name |
| `vault` | `complete -C /usr/local/bin/vault vault` | C-Mode, das was `vault -autocomplete-install` sonst in eine Dotfile schreibt |

`kubectx` und `kubens` haben die Completion nicht im Binary, sondern als Skript im Repo — wird aus demselben Tag geladen, aus dem auch die Binaries kommen.

## Bewusst ausgelassen

- `govc` bringt keine mit
- `kubectl-oadp completion bash` blockiert auf eine Cluster-Verbindung (`rc=124` nach 25s Timeout), würde den Build also hängen lassen

## Verifikation

Für jedes Tool im laufenden Image geprüft, ob der Aufruf funktioniert, mehr als 500 Bytes liefert und tatsächlich `complete`/`compgen` enthält — daraus ist die obige Aufteilung entstanden. Dazu 5 neue Structure-Tests, darunter einer, der in einer interaktiven Shell (`bash -ic`) für alle 19 Tools prüft, ob eine Completion registriert ist.

hadolint und yamllint sind sauber.

**Nicht gelaufen ist der vollständige Image-Build**: `galaxy.ansible.com` liefert seit einigen Stunden abgeschnittene Antworten (`IncompleteRead`), woran `ansible-galaxy` mehrere Layer vor dieser Änderung scheitert. Drei direkte API-Aufrufe zum Vergleich: 200, 200, Verbindungsabbruch. Die CI holt den Build nach, sobald Galaxy wieder stabil ist.

## Randnotiz

`ansible-galaxy` schreibt die abgeschnittene Antwort in seinen Response-Cache und scheitert danach mit `Missing expected 'results' in ansible-galaxy cache`, also mit einer irreführenden Meldung statt eines erneuten Abrufs. Falls der nächtliche Build daran öfter hängt, wäre ein Retry um den Aufruf plus `--no-cache` die Gegenmaßnahme — bewusst nicht Teil dieses PRs.
